### PR TITLE
[Optional] Allow Invalid Certificates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+ACCEPT_INVALID_CERTS="0"
 ANNA_COOKIE="anna_cookie"
 DOMAIN='domain.domain'
 BOARD='board'

--- a/src/connection/model.rs
+++ b/src/connection/model.rs
@@ -46,6 +46,7 @@ pub struct ChanConnection {
 
 impl ChanConnection {
     pub async fn init(
+        accept_invalid_certs: bool,
         anna_cookie: String,
         get_url: String,
         post_url: String,
@@ -53,6 +54,7 @@ impl ChanConnection {
         trip: String,
     ) -> Result<Self, anyhow::Error> {
         let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(accept_invalid_certs)
             .cookie_store(true)
             .build()?;
         let queue = MessageQueue::init().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,15 @@ async fn main() -> Result<(), anyhow::Error> {
     let anna_cookie = env::var("ANNA_COOKIE")
         .expect("ANNA_COOKIE is not set in the .env file");
     // let anna_cookie = "";
+    
+    let accept_invalid_certs = if (
+        env::var("ACCEPT_INVALID_CERTS")
+            .expect("ACCEPT_INVALID_CERTS is not set in the .env file")
+        ) == "1" {
+            true
+        } else {
+            false
+        };
 
     // kotchan.fun
     let domain = env::var("DOMAIN")
@@ -44,7 +53,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // TODO: load chat, name and trip from env variables and save in the connection
 
     let mut con = connection::ChanConnection::init(
-        anna_cookie, get_url, post_url, name, trip
+        accept_invalid_certs, anna_cookie, get_url, post_url, name, trip
     ).await?;
     
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,6 @@ use dotenv::dotenv;
 async fn main() -> Result<(), anyhow::Error> {
     dotenv().ok();
     
-    // anna_nolimit_cookie1
-    let anna_cookie = env::var("ANNA_COOKIE")
-        .expect("ANNA_COOKIE is not set in the .env file");
-    // let anna_cookie = "";
-    
     let accept_invalid_certs = if (
         env::var("ACCEPT_INVALID_CERTS")
             .expect("ACCEPT_INVALID_CERTS is not set in the .env file")
@@ -33,6 +28,11 @@ async fn main() -> Result<(), anyhow::Error> {
             false
         };
 
+    // anna_nolimit_cookie1
+    let anna_cookie = env::var("ANNA_COOKIE")
+        .expect("ANNA_COOKIE is not set in the .env file");
+    // let anna_cookie = "";
+    
     // kotchan.fun
     let domain = env::var("DOMAIN")
         .expect("DOMAIN is not set in the .env file");


### PR DESCRIPTION
Adds a dotenv variable to allow for connections over https with an invalid certificate.